### PR TITLE
Add support of AMQP queues (#1063)

### DIFF
--- a/contribs/build.gradle
+++ b/contribs/build.gradle
@@ -13,6 +13,8 @@ dependencies {
 
 	compile "io.nats:java-nats-streaming:${revNatsStreaming}"
 
+	compile "com.rabbitmq:amqp-client:${revAmqpClient}"
+
 	compileOnly "javax.ws.rs:jsr311-api:${revJsr311Api}"
 	compile "io.swagger:swagger-jaxrs:${revSwagger}"
 
@@ -20,4 +22,5 @@ dependencies {
 
 	testCompile "org.eclipse.jetty:jetty-server:${revJetteyServer}"
 	testCompile "org.eclipse.jetty:jetty-servlet:${revJettyServlet}"
+	testCompile "org.slf4j:slf4j-log4j12:${revSlf4jlog4j}"
 }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/AMQModule.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/AMQModule.java
@@ -1,0 +1,83 @@
+package com.netflix.conductor.contribs;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.ProvidesIntoMap;
+import com.google.inject.multibindings.StringMapKey;
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.contribs.queue.QueueManager;
+import com.netflix.conductor.contribs.queue.amqp.AMQObservableQueue;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.events.EventQueueProvider;
+import com.netflix.conductor.core.events.amqp.AMQEventQueueProvider;
+import com.netflix.conductor.core.events.queue.ObservableQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Named;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.netflix.conductor.core.events.EventQueues.EVENT_QUEUE_PROVIDERS_QUALIFIER;
+
+/**
+ * Module for support of AMQP queues
+ * Do not forget to define me into the configuration file:
+ * <pre>
+ *     conductor.additional.modules=com.netflix.conductor.contribs.AMQModule
+ * </pre>
+ * Created at 19/03/2019 16:33
+ *
+ * @author Mickaël GREGORI <mickael.gregori@alchimie.com>
+ * @version $Id$
+ */
+public class AMQModule extends AbstractModule {
+
+    private static final boolean USE_EXCHANGE_BY_DEFAULT = false;
+
+    private static Logger logger = LoggerFactory.getLogger(AMQModule.class);
+
+    @Override
+    protected void configure() {
+        bind(QueueManager.class).asEagerSingleton();
+        logger.info("RabbitMQ Module configured ...");
+    }
+
+    @ProvidesIntoMap
+    @StringMapKey("amqp")
+    @Singleton
+    @Named(EVENT_QUEUE_PROVIDERS_QUALIFIER)
+    public EventQueueProvider getAMQQueueEventQueueProvider(Configuration config) {
+        return new AMQEventQueueProvider(config, false);
+    }
+
+    @ProvidesIntoMap
+    @StringMapKey("amqp_exchange")
+    @Singleton
+    @Named(EVENT_QUEUE_PROVIDERS_QUALIFIER)
+    public EventQueueProvider getAMQExchangeEventQueueProvider(Configuration config) {
+        return new AMQEventQueueProvider(config, true);
+    }
+
+    @Provides
+    public Map<Task.Status, ObservableQueue> getQueues(Configuration config) {
+        String stack = "";
+        if(config.getStack() != null && config.getStack().length() > 0) {
+            stack = config.getStack() + "_";
+        }
+        final boolean useExchange = config.getBooleanProperty("workflow.listener.queue.useExchange",
+                USE_EXCHANGE_BY_DEFAULT);
+        Task.Status[] statuses = new Task.Status[]{Task.Status.COMPLETED, Task.Status.FAILED};
+        Map<Task.Status, ObservableQueue> queues = new HashMap<>();
+        for(Task.Status status : statuses) {
+            String queueName = config.getProperty("workflow.listener.queue.prefix",
+                    config.getAppId() + "_amqp_notify_" + stack + status.name());
+            final ObservableQueue queue = new AMQObservableQueue.Builder(config)
+                    .build(useExchange, queueName);
+            queues.put(status, queue);
+        }
+
+        return queues;
+    }
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/AbstractObservableQueue.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/AbstractObservableQueue.java
@@ -1,0 +1,37 @@
+package com.netflix.conductor.contribs.queue;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.conductor.core.events.queue.Message;
+import com.netflix.conductor.core.events.queue.ObservableQueue;
+import rx.Observable;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created at 22/03/2019 17:37
+ *
+ * @author Mickaël GREGORI <mickael.gregori@alchimie.com>
+ * @version $Id$
+ */
+public abstract class AbstractObservableQueue implements ObservableQueue {
+
+    protected int pollTimeInMS;
+
+    public int getPollTimeInMS() {
+        return pollTimeInMS;
+    }
+
+    protected abstract List<Message> receiveMessages();
+
+    @VisibleForTesting
+    public Observable.OnSubscribe<Message> getOnSubscribe() {
+        return subscriber -> {
+            Observable<Long> interval = Observable.interval(pollTimeInMS, TimeUnit.MILLISECONDS);
+            interval.flatMap((Long x)->{
+                List<Message> msgs = receiveMessages();
+                return Observable.from(msgs);
+            }).subscribe(subscriber::onNext, subscriber::onError);
+        };
+    }
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQConstants.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQConstants.java
@@ -1,0 +1,26 @@
+package com.netflix.conductor.contribs.queue.amqp;
+
+/**
+ * Created at 26/03/2019 10:40
+ *
+ * @author Mickaël GREGORI <mickael.gregori@alchimie.com>
+ * @version $Id$
+ */
+interface AMQConstants {
+    String AMQP_QUEUE_TYPE = "amqp";
+    String AMQP_EXCHANGE_TYPE = "amqp_exchange";
+
+    String PROPERTY_KEY_TEMPLATE = "workflow.event.queues.amqp.%s";
+
+    String DEFAULT_CONTENT_TYPE = "application/json";
+    String DEFAULT_CONTENT_ENCODING = "UTF-8";
+    String DEFAULT_EXCHANGE_TYPE = "topic";
+
+    boolean DEFAULT_DURABLE = true;
+    boolean DEFAULT_EXCLUSIVE = false;
+    boolean DEFAULT_AUTO_DELETE = false;
+
+    int DEFAULT_DELIVERY_MODE = 2; // Persistent messages
+    int DEFAULT_BATCH_SIZE = 1;
+    int DEFAULT_POLL_TIME_MS = 100;
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQObservableQueue.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQObservableQueue.java
@@ -1,0 +1,522 @@
+package com.netflix.conductor.contribs.queue.amqp;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+import com.netflix.conductor.contribs.queue.AbstractObservableQueue;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.events.queue.Message;
+import com.netflix.conductor.metrics.Monitors;
+import com.rabbitmq.client.*;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import static com.netflix.conductor.contribs.queue.amqp.AMQProperties.*;
+
+/**
+ * Created at 19/03/2019 16:38
+ *
+ * @author Mickaël GREGORI <mickael.gregori@alchimie.com>
+ * @version $Id$
+ */
+public class AMQObservableQueue extends AbstractObservableQueue implements AMQConstants {
+
+    private static Logger logger = LoggerFactory.getLogger(AMQObservableQueue.class);
+
+    private final AMQSettings settings;
+
+    private final int batchSize;
+
+    private boolean useExchange;
+
+    private boolean isConnOpened = false, isChanOpened = false;
+
+    private ConnectionFactory factory;
+    private Connection connection;
+    private Channel channel;
+    private Address[] addresses;
+
+    AMQObservableQueue(final ConnectionFactory factory, final Address[] addresses, final boolean useExchange,
+                       final AMQSettings settings, final int batchSize, final int pollTimeInMS) {
+        if (factory == null) {
+            throw new IllegalArgumentException("Connection factory is undefined");
+        }
+        if (addresses == null || addresses.length == 0) {
+            throw new IllegalArgumentException("Addresses are undefined");
+        }
+        if (settings == null) {
+            throw new IllegalArgumentException("Settings are undefined");
+        }
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("Batch size must be greater than 0");
+        }
+        if (pollTimeInMS <= 0) {
+            throw new IllegalArgumentException("Poll time must be greater than 0 ms");
+        }
+        this.factory = factory;
+        this.addresses = addresses;
+        this.useExchange = useExchange;
+        this.settings = settings;
+        this.batchSize = batchSize;
+        this.pollTimeInMS = pollTimeInMS;
+    }
+
+    private void connect() {
+        if (isConnOpened) {
+            return;
+        }
+        try {
+            connection = factory.newConnection(addresses);
+            isConnOpened = connection.isOpen();
+            if (!isConnOpened) {
+                throw new RuntimeException("Failed to open connection");
+            }
+        }
+        catch (final IOException e) {
+            isConnOpened = false;
+            final String error = "IO error while connecting to "+ Arrays.stream(addresses)
+                    .map(address -> address.toString()).collect(Collectors.joining(","));
+            logger.error(error, e);
+            throw new RuntimeException(error, e);
+        }
+        catch (final TimeoutException e) {
+            isConnOpened = false;
+            final String error = "Timeout while connecting to "+ Arrays.stream(addresses)
+                    .map(address -> address.toString()).collect(Collectors.joining(","));
+            logger.error(error, e);
+            throw new RuntimeException(error, e);
+        }
+    }
+
+    private boolean isClosed() {
+        return !isConnOpened && !isChanOpened;
+    }
+
+    private void open() {
+        connect();
+    }
+
+    @Override
+    public Observable<Message> observe() {
+        Observable.OnSubscribe<Message> subscriber = getOnSubscribe();
+        return Observable.create(subscriber);
+    }
+
+    @Override
+    public String getType() {
+        return useExchange ? AMQP_EXCHANGE_TYPE : AMQP_QUEUE_TYPE;
+    }
+
+    @Override
+    public String getName() {
+        return settings.getQueueOrExchangeName();
+    }
+
+    @Override
+    public String getURI() {
+        return settings.getQueueOrExchangeName();
+    }
+
+    public ConnectionFactory getConnectionFactory() {
+        return factory;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public AMQSettings getSettings() {
+        return settings;
+    }
+
+    public Address[] getAddresses() {
+        return addresses;
+    }
+
+    @Override
+    public List<String> ack(List<Message> messages) {
+        final List<String> processedDeliveryTags = new ArrayList<>();
+        for (final Message message : messages) {
+            try {
+                if (logger.isInfoEnabled()) {
+                    logger.info("ACK message with delivery tag {}", message.getReceipt());
+                }
+                getOrCreateChannel().basicAck(Long.valueOf(message.getReceipt()), false);
+                // Message ACKed
+                processedDeliveryTags.add(message.getReceipt());
+            }
+            catch (final IOException e) {
+                logger.error("Cannot ACK message with delivery tag {}", message.getReceipt(), e);
+            }
+        }
+        return processedDeliveryTags;
+    }
+
+    private static AMQP.BasicProperties buildBasicProperties(final Message message,
+                                                             final AMQSettings settings) {
+        return new AMQP.BasicProperties.Builder()
+                .messageId(StringUtils.isEmpty(message.getId()) ?
+                        UUID.randomUUID().toString() :
+                        message.getId())
+                .correlationId(StringUtils.isEmpty(message.getReceipt()) ?
+                        UUID.randomUUID().toString() :
+                        message.getReceipt())
+                .contentType(settings.getContentType())
+                .contentEncoding(settings.getContentEncoding())
+                .deliveryMode(settings.getDeliveryMode())
+                .build();
+    }
+
+    private void publishMessage(Message message, String exchange, String routingKey) {
+        try {
+            final String payload = message.getPayload();
+            getOrCreateChannel().basicPublish(exchange,
+                    routingKey,
+                    buildBasicProperties(message, settings),
+                    payload.getBytes(settings.getContentEncoding()));
+            logger.info(String.format("Published message to %s: %s", exchange, payload));
+        } catch (Exception ex) {
+            logger.error("Failed to publish message {} to {}", message.getPayload(), exchange, ex);
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    public void publish(List<Message> messages) {
+        try {
+            final String exchange, routingKey;
+            if (useExchange) {
+                // Use exchange + routing key for publishing
+                getOrCreateExchange(settings.getQueueOrExchangeName(), settings.getExchangeType(),
+                        settings.isDurable(), settings.autoDelete(), settings.getArguments());
+                exchange = settings.getQueueOrExchangeName();
+                routingKey = settings.getRoutingKey();
+            }
+            else {
+                // Use queue for publishing
+                final AMQP.Queue.DeclareOk declareOk = getOrCreateQueue(settings.getQueueOrExchangeName(),
+                        settings.isDurable(), settings.isExclusive(), settings.autoDelete(),
+                        settings.getArguments());
+                exchange = StringUtils.EMPTY; // Empty exchange name for queue
+                routingKey = declareOk.getQueue(); // Routing name is the name of queue
+            }
+            messages.forEach(message -> publishMessage(message, exchange, routingKey));
+        } catch (final RuntimeException ex) {
+            throw ex;
+        } catch (final Exception ex) {
+            logger.error("Failed to publish messages: {}", ex.getMessage(), ex);
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    public void setUnackTimeout(Message message, long l) {
+    }
+
+    @Override
+    public long size() {
+        try {
+            return getOrCreateChannel().messageCount(settings.getQueueOrExchangeName());
+        }
+        catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        closeChannel();
+        closeConnection();
+    }
+
+    public static class Builder {
+
+        private Address[] addresses;
+
+        private int batchSize;
+        private int pollTimeInMS;
+
+        private ConnectionFactory factory;
+        private Configuration config;
+
+        public Builder(Configuration config) {
+            this.config = config;
+            this.addresses = buildAddressesFromHosts();
+            this.factory = buildConnectionFactory();
+            /* messages polling settings */
+            this.batchSize = config.getIntProperty(String.format(PROPERTY_KEY_TEMPLATE, PROPERTY_BATCH_SIZE),
+                    DEFAULT_BATCH_SIZE);
+            this.pollTimeInMS = config.getIntProperty(String.format(PROPERTY_KEY_TEMPLATE, PROPERTY_POLL_TIME_IN_MS),
+                    DEFAULT_POLL_TIME_MS);
+        }
+
+        private Address[] buildAddressesFromHosts() {
+            // Read hosts from config
+            final String hosts = config.getProperty(String.format(PROPERTY_KEY_TEMPLATE, PROPERTY_HOSTS),
+                    ConnectionFactory.DEFAULT_HOST);
+            if (StringUtils.isEmpty(hosts)) {
+                throw new IllegalArgumentException("Hosts are undefined");
+            }
+            return Address.parseAddresses(hosts);
+        }
+
+        private ConnectionFactory buildConnectionFactory() {
+            final ConnectionFactory factory = new ConnectionFactory();
+            // Get rabbitmq username from config
+            final String username = config.getProperty(String.format(PROPERTY_KEY_TEMPLATE, PROPERTY_USERNAME),
+                    ConnectionFactory.DEFAULT_USER);
+            if (StringUtils.isEmpty(username)) {
+                throw new IllegalArgumentException("Username is null or empty");
+            }
+            else {
+                factory.setUsername(username);
+            }
+            // Get rabbitmq password from config
+            final String password = config.getProperty(String.format(PROPERTY_KEY_TEMPLATE, PROPERTY_PASSWORD),
+                    ConnectionFactory.DEFAULT_PASS);
+            if (StringUtils.isEmpty(password)) {
+                throw new IllegalArgumentException("Password is null or empty");
+            }
+            else {
+                factory.setPassword(password);
+            }
+            // Get vHost from config
+            final String virtualHost = config.getProperty(String.format(PROPERTY_KEY_TEMPLATE, PROPERTY_VIRTUAL_HOST),
+                    ConnectionFactory.DEFAULT_VHOST);
+            if (StringUtils.isEmpty(virtualHost)) {
+                throw new IllegalArgumentException("Virtual host is null or empty");
+            }
+            else {
+                factory.setVirtualHost(virtualHost);
+            }
+            // Get server port from config
+            final int port = config.getIntProperty(String.format(PROPERTY_KEY_TEMPLATE, PROPERTY_PORT),
+                    AMQP.PROTOCOL.PORT);
+            if (port <= 0) {
+                throw new IllegalArgumentException("Port must be greater than 0");
+            }
+            else {
+                factory.setPort(port);
+            }
+            // Get connection timeout from config
+            final int connectionTimeout = config.getIntProperty(String.format(PROPERTY_KEY_TEMPLATE, PROPERTY_CONNECTION_TIMEOUT),
+                    ConnectionFactory.DEFAULT_CONNECTION_TIMEOUT);
+            if (connectionTimeout <= 0) {
+                throw new IllegalArgumentException("Connection timeout must be greater than 0");
+            }
+            else {
+                factory.setConnectionTimeout(connectionTimeout);
+            }
+            final boolean useNio = config.getBoolProperty(String.format(PROPERTY_KEY_TEMPLATE, PROPERTY_USE_NIO), false);
+            if (useNio) {
+                factory.useNio();
+            }
+            return factory;
+        }
+
+        public AMQObservableQueue build(final boolean useExchange, final String queueURI) {
+            final AMQSettings settings = new AMQSettings(config).fromURI(queueURI);
+            return new AMQObservableQueue(factory, addresses, useExchange, settings,
+                    batchSize, pollTimeInMS);
+        }
+    }
+
+    private Channel getOrCreateChannel() {
+        if (!isConnOpened) {
+            open();
+        }
+        // Return the existing channel if it's still opened
+        if (channel != null && isChanOpened) {
+            return channel;
+        }
+        // Channel creation is required
+        try {
+            channel = null;
+            channel = connection.createChannel();
+            channel.addShutdownListener(cause -> {
+                isChanOpened = false;
+                logger.error("Channel has been shutdown: {}", cause.getMessage(), cause);
+            });
+        }
+        catch (final IOException e) {
+            throw new RuntimeException("Cannot open channel on "+ Arrays.stream(addresses)
+                    .map(address -> address.toString())
+                    .collect(Collectors.joining(",")), e);
+        }
+        isChanOpened = channel.isOpen();
+        if (!isChanOpened) {
+            throw new RuntimeException("Fail to open channel");
+        }
+        return channel;
+    }
+
+    private AMQP.Exchange.DeclareOk getOrCreateExchange() throws IOException {
+        return getOrCreateExchange(settings.getQueueOrExchangeName(), settings.getExchangeType(),
+                settings.isDurable(), settings.autoDelete(), settings.getArguments());
+    }
+
+    private AMQP.Exchange.DeclareOk getOrCreateExchange(final String name, final String type, final boolean isDurable,
+                                                        final boolean autoDelete, final Map<String, Object> arguments)
+            throws IOException {
+        if (StringUtils.isEmpty(name)) {
+            throw new RuntimeException("Exchange name is undefined");
+        }
+        if (StringUtils.isEmpty(type)) {
+            throw new RuntimeException("Exchange type is undefined");
+        }
+        if (!isClosed()) {
+            open();
+        }
+        AMQP.Exchange.DeclareOk declareOk;
+        try {
+            declareOk = getOrCreateChannel().exchangeDeclarePassive(name);
+        }
+        catch (final IOException e) {
+            logger.warn("Exchange {} of type {} might not exists", name, type, e);
+            declareOk = getOrCreateChannel().exchangeDeclare(name, type, isDurable,
+                    autoDelete, arguments);
+        }
+        return declareOk;
+    }
+
+    private AMQP.Queue.DeclareOk getOrCreateQueue() throws IOException {
+        return getOrCreateQueue(settings.getQueueOrExchangeName(), settings.isDurable(), settings.isExclusive(),
+                settings.autoDelete(), settings.getArguments());
+    }
+
+    private AMQP.Queue.DeclareOk getOrCreateQueue(final String name, final boolean isDurable, final boolean isExclusive,
+                                                  final boolean autoDelete, final Map<String, Object> arguments)
+            throws IOException {
+        if (Strings.isNullOrEmpty(name)) {
+            throw new RuntimeException("Queue name is undefined");
+        }
+        if (!isClosed()) {
+            open();
+        }
+        AMQP.Queue.DeclareOk declareOk;
+        try {
+            declareOk = getOrCreateChannel().queueDeclarePassive(name);
+        }
+        catch (final IOException e) {
+            logger.warn("Queue {} might not exists", name, e);
+            declareOk = getOrCreateChannel().queueDeclare(name, isDurable, isExclusive,
+                    autoDelete, arguments);
+        }
+        return declareOk;
+    }
+
+    private void closeConnection() {
+        if (connection == null) {
+            logger.warn("Connection is null. Do not close it");
+        }
+        else {
+            try {
+                if (connection.isOpen()) {
+                    try {
+                        if (logger.isInfoEnabled()) {
+                            logger.info("Close AMQP connection");
+                        }
+                        connection.close();
+                    } catch (final IOException e) {
+                        logger.warn("Fail to close connection: {}", e.getMessage(), e);
+                    }
+                }
+            }
+            finally {
+                isConnOpened = connection.isOpen();
+                connection = null;
+            }
+        }
+    }
+
+    private void closeChannel() {
+        if (channel == null) {
+            logger.warn("Channel is null. Do not close it");
+        }
+        else {
+            try {
+                if (channel.isOpen()) {
+                    try {
+                        if (logger.isInfoEnabled()) {
+                            logger.info("Close AMQP channel");
+                        }
+                        channel.close();
+                    } catch (final TimeoutException e) {
+                        logger.warn("Timeout while closing channel: {}", e.getMessage(), e);
+                    } catch (final IOException e) {
+                        logger.warn("Fail to close channel: {}", e.getMessage(), e);
+                    }
+                }
+            }
+            finally {
+                channel = null;
+            }
+        }
+    }
+
+    private static Message asMessage(AMQSettings settings, GetResponse response) throws Exception {
+        if (response == null) {
+            return null;
+        }
+        final Message message = new Message();
+        message.setId(response.getProps().getMessageId());
+        message.setPayload(new String(response.getBody(), settings.getContentEncoding()));
+        message.setReceipt(String.valueOf(response.getEnvelope().getDeliveryTag()));
+        return message;
+    }
+
+    private List<Message> receiveMessagesFromQueue(String queueName) throws Exception {
+        final List<Message> messages = new LinkedList<>();
+        Message message;
+        int nb = 0;
+        do {
+            message = asMessage(settings, getOrCreateChannel().basicGet(queueName, false));
+            if (message != null) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Got message with ID {} and receipt {}", message.getId(), message.getReceipt());
+                }
+                messages.add(message);
+            }
+        }
+        while (++nb < batchSize && message != null);
+        Monitors.recordEventQueueMessagesProcessed(getType(), queueName, messages.size());
+        return messages;
+    }
+
+    @VisibleForTesting
+    protected List<Message> receiveMessages() {
+        try {
+            getOrCreateChannel().basicQos(batchSize);
+            String queueName;
+            if (useExchange) {
+                // Consume messages from an exchange
+                getOrCreateExchange();
+                // Declare an exclusive not durable with auto-delete queue
+                final AMQP.Queue.DeclareOk declareOk = getOrCreateQueue(
+                        String.format("bound_to_%s", settings.getQueueOrExchangeName()),
+                        false, true, true, Maps.newHashMap());
+                // Bind the declared queue to exchange
+                queueName = declareOk.getQueue();
+                getOrCreateChannel().queueBind(queueName, settings.getQueueOrExchangeName(), settings.getRoutingKey());
+            }
+            else {
+                // Consume messages from a queue
+                queueName = getOrCreateQueue().getQueue();
+            }
+            // Consume messages
+            return receiveMessagesFromQueue(queueName);
+        }
+        catch (Exception exception) {
+            logger.error("Exception while getting messages from RabbitMQ", exception);
+            Monitors.recordObservableQMessageReceivedErrors(getType());
+        }
+        return new ArrayList<>();
+    }
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQProperties.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQProperties.java
@@ -1,0 +1,41 @@
+package com.netflix.conductor.contribs.queue.amqp;
+
+/**
+ * Last properties name for AMQP queues
+ * Created at 22/03/2019 17:19
+ *
+ * @author Mickaël GREGORI <mickael.gregori@alchimie.com>
+ * @version $Id$
+ */
+public enum AMQProperties {
+
+    PROPERTY_CONTENT_TYPE("contentType"),
+    PROPERTY_CONTENT_ENCODING("contentEncoding"),
+    PROPERTY_IS_DURABLE("durable"),
+    PROPERTY_IS_EXCLUSIVE("exclusive"),
+    PROPERTY_AUTO_DELETE("autoDelete"),
+    PROPERTY_DELIVERY_MODE("deliveryMode"),
+    PROPERTY_EXCHANGE_TYPE("exchangeType"),
+    PROPERTY_MAX_PRIORITY("maxPriority"),
+    PROPERTY_BATCH_SIZE("batchSize"),
+    PROPERTY_POLL_TIME_IN_MS("pollTimeInMs"),
+    PROPERTY_HOSTS("hosts"),
+    PROPERTY_USERNAME("username"),
+    PROPERTY_PASSWORD("password"),
+    PROPERTY_VIRTUAL_HOST("virtualHost"),
+    PROPERTY_PORT("port"),
+    PROPERTY_CONNECTION_TIMEOUT("connectionTimeout"),
+    PROPERTY_USE_NIO("useNio");
+
+    String propertyName;
+
+    AMQProperties(String propertyName) {
+        this.propertyName = propertyName;
+    }
+
+    @Override
+    public String toString() {
+        return propertyName;
+    }
+}
+

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQQueryParameters.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQQueryParameters.java
@@ -1,0 +1,31 @@
+package com.netflix.conductor.contribs.queue.amqp;
+
+/**
+ * Last properties name for AMQP queues
+ * Created at 22/03/2019 17:19
+ *
+ * @author Mickaël GREGORI <mickael.gregori@alchimie.com>
+ * @version $Id$
+ */
+public enum AMQQueryParameters {
+
+    PARAM_EXCHANGE_TYPE("exchangeType"),
+    PARAM_ROUTING_KEY("routingKey"),
+    PARAM_DELIVERY_MODE("deliveryMode"),
+    PARAM_DURABLE("durable"),
+    PARAM_EXCLUSIVE("exclusive"),
+    PARAM_AUTO_DELETE("autoDelete"),
+    PARAM_MAX_PRIORITY("maxPriority");
+
+    String propertyName;
+
+    AMQQueryParameters(String propertyName) {
+        this.propertyName = propertyName;
+    }
+
+    @Override
+    public String toString() {
+        return propertyName;
+    }
+}
+

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQSettings.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQSettings.java
@@ -1,0 +1,223 @@
+package com.netflix.conductor.contribs.queue.amqp;
+
+import com.netflix.conductor.core.config.Configuration;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.netflix.conductor.contribs.queue.amqp.AMQProperties.*;
+import static com.netflix.conductor.contribs.queue.amqp.AMQQueryParameters.*;
+
+/**
+ * Settings for publishing messages to AMQP queue or exchange \w routing key
+ * Created at 22/03/2019 11:35
+ *
+ * @author Mickaël GREGORI <mickael.gregori@alchimie.com>
+ * @version $Id$
+ */
+public class AMQSettings implements AMQConstants {
+
+    private static final Pattern URI_PATTERN = Pattern.compile("^(?:amqp\\-(queue|exchange))?\\:?(?<name>[^\\?]+)\\??(?<params>.*)$",
+            Pattern.CASE_INSENSITIVE);
+
+    private String queueOrExchangeName;
+    private String exchangeType;
+    private String routingKey;
+    private String contentEncoding;
+    private String contentType;
+
+    private boolean durable;
+    private boolean exclusive;
+    private boolean autoDelete;
+
+    private int deliveryMode;
+
+    private final Map<String, Object> arguments = new HashMap<>();
+
+    public AMQSettings(final Configuration config) {
+        // Initialize with a default values
+        durable = config.getBooleanProperty(String.format(PROPERTY_KEY_TEMPLATE, PROPERTY_IS_DURABLE), DEFAULT_DURABLE);
+        exclusive = config.getBooleanProperty(String.format(PROPERTY_KEY_TEMPLATE, PROPERTY_IS_EXCLUSIVE), DEFAULT_EXCLUSIVE);
+        autoDelete = config.getBooleanProperty(String.format(PROPERTY_KEY_TEMPLATE, PROPERTY_AUTO_DELETE), DEFAULT_AUTO_DELETE);
+        contentType = config.getProperty(String.format(PROPERTY_KEY_TEMPLATE, PROPERTY_CONTENT_TYPE), DEFAULT_CONTENT_TYPE);
+        contentEncoding = config.getProperty(String.format(PROPERTY_KEY_TEMPLATE, PROPERTY_CONTENT_ENCODING), DEFAULT_CONTENT_ENCODING);
+        exchangeType = config.getProperty(String.format(PROPERTY_KEY_TEMPLATE, AMQP_EXCHANGE_TYPE), DEFAULT_EXCHANGE_TYPE);
+        routingKey = StringUtils.EMPTY;
+        // Set common settings for publishing and consuming
+        setDeliveryMode(config.getIntProperty(String.format(PROPERTY_KEY_TEMPLATE, PROPERTY_DELIVERY_MODE), DEFAULT_DELIVERY_MODE));
+    }
+
+    public final boolean isDurable() {
+        return durable;
+    }
+
+    public final boolean isExclusive() {
+        return exclusive;
+    }
+
+    public final boolean autoDelete() {
+        return autoDelete;
+    }
+
+    public final Map<String, Object> getArguments() {
+        return arguments;
+    }
+
+    public final String getContentEncoding() {
+        return contentEncoding;
+    }
+
+    /**
+     * Use queue for publishing
+     * @param queueName the name of queue
+     */
+    public void setQueue(String queueName) {
+        if (StringUtils.isEmpty(queueName)) {
+            throw new IllegalArgumentException("Queue name for publishing is undefined");
+        }
+        this.queueOrExchangeName = queueName;
+    }
+
+    public String getQueueOrExchangeName() {
+        return queueOrExchangeName;
+    }
+
+    public String getExchangeType() {
+        return exchangeType;
+    }
+
+    public String getRoutingKey() {
+        return routingKey;
+    }
+
+    public int getDeliveryMode() {
+        return deliveryMode;
+    }
+
+    public AMQSettings setDeliveryMode(int deliveryMode) {
+        if (deliveryMode < 1 && deliveryMode > 2) {
+            throw new IllegalArgumentException("Delivery mode must be 1 or 2");
+        }
+        this.deliveryMode = deliveryMode;
+        return this;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    /**
+     * Complete settings from the queue URI.
+     *
+     * <u>Example for queue:</u>
+     * <pre>
+     * amqp-queue:myQueue?deliveryMode=1&autoDelete=true&exclusive=true
+     * </pre>
+     * <u>Example for exchange:</u>
+     * <pre>
+     * amqp-exchange:myExchange?exchangeType=topic&routingKey=myRoutingKey&exclusive=true
+     * </pre>
+     * @param queueURI
+     * @return
+     */
+    public final AMQSettings fromURI(final String queueURI) {
+        final Matcher matcher = URI_PATTERN.matcher(queueURI);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Queue URI doesn't matches the expected regexp");
+        }
+
+        // Set name of queue or exchange from group "name"
+        queueOrExchangeName = matcher.group("name");
+
+        if (matcher.groupCount() > 1) {
+            final String queryParams = matcher.group("params");
+            if (StringUtils.isNotEmpty(queryParams)) {
+                // Handle parameters
+                Arrays.stream(queryParams.split("\\s*\\&\\s*")).forEach(
+                    param -> {
+                        final String[] kv = param.split("\\s*=\\s*");
+                        if (kv.length == 2) {
+                            if (kv[0].equalsIgnoreCase(String.valueOf(PARAM_EXCHANGE_TYPE))) {
+                                String value = kv[1];
+                                if (StringUtils.isEmpty(value)) {
+                                    throw new IllegalArgumentException("The provided exchange type is empty");
+                                }
+                                exchangeType = value;
+                            }
+                            if (kv[0].equalsIgnoreCase((String.valueOf(PARAM_ROUTING_KEY)))) {
+                                String value = kv[1];
+                                if (StringUtils.isEmpty(value)) {
+                                    throw new IllegalArgumentException("The provided routing key is empty");
+                                }
+                                routingKey = value;
+                            }
+                            if (kv[0].equalsIgnoreCase((String.valueOf(PARAM_DURABLE)))) {
+                                durable = Boolean.valueOf(kv[1]);
+                            }
+                            if (kv[0].equalsIgnoreCase((String.valueOf(PARAM_EXCLUSIVE)))) {
+                                exclusive = Boolean.valueOf(kv[1]);
+                            }
+                            if (kv[0].equalsIgnoreCase((String.valueOf(PARAM_AUTO_DELETE)))) {
+                                autoDelete = Boolean.valueOf(kv[1]);
+                            }
+                            if (kv[0].equalsIgnoreCase((String.valueOf(PARAM_DELIVERY_MODE)))) {
+                                setDeliveryMode(Integer.valueOf(kv[1]));
+                            }
+                            if (kv[0].equalsIgnoreCase((String.valueOf(PARAM_MAX_PRIORITY)))) {
+                                arguments.put("x-max-priority", Integer.valueOf(kv[1]));
+                            }
+                        }
+                    }
+                );
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AMQSettings)) return false;
+        AMQSettings that = (AMQSettings) o;
+        return isDurable() == that.isDurable() &&
+                isExclusive() == that.isExclusive() &&
+                autoDelete == that.autoDelete &&
+                getDeliveryMode() == that.getDeliveryMode() &&
+                Objects.equals(getQueueOrExchangeName(), that.getQueueOrExchangeName()) &&
+                Objects.equals(getExchangeType(), that.getExchangeType()) &&
+                Objects.equals(getRoutingKey(), that.getRoutingKey()) &&
+                Objects.equals(getContentType(), that.getContentType()) &&
+                Objects.equals(getContentEncoding(), that.getContentEncoding()) &&
+                Objects.equals(getArguments(), that.getArguments());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getQueueOrExchangeName(), getExchangeType(), getRoutingKey(),
+                getContentType(), isDurable(), isExclusive(), autoDelete, getDeliveryMode(),
+                getContentEncoding(), getArguments());
+    }
+
+    @Override
+    public String toString() {
+        return "AMQSettings{" +
+                "queueOrExchangeName='" + queueOrExchangeName + '\'' +
+                ", exchangeType='" + exchangeType + '\'' +
+                ", routingKey='" + routingKey + '\'' +
+                ", contentType='" + contentType + '\'' +
+                ", durable=" + durable +
+                ", exclusive=" + exclusive +
+                ", autoDelete=" + autoDelete +
+                ", deliveryMode=" + deliveryMode +
+                ", contentEncoding='" + contentEncoding + '\'' +
+                ", arguments=" + arguments +
+                ", durable=" + isDurable() +
+                ", exclusive=" + isExclusive() +
+                '}';
+    }
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/queue/sqs/SQSObservableQueue.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/queue/sqs/SQSObservableQueue.java
@@ -43,8 +43,8 @@ import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
 import com.amazonaws.services.sqs.model.SendMessageBatchResult;
 import com.amazonaws.services.sqs.model.SetQueueAttributesResult;
 import com.google.common.annotations.VisibleForTesting;
+import com.netflix.conductor.contribs.queue.AbstractObservableQueue;
 import com.netflix.conductor.core.events.queue.Message;
-import com.netflix.conductor.core.events.queue.ObservableQueue;
 import com.netflix.conductor.metrics.Monitors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,14 +57,13 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
  * @author Viren
  *
  */
-public class SQSObservableQueue implements ObservableQueue {
+public class SQSObservableQueue extends AbstractObservableQueue {
 
 	private static Logger logger = LoggerFactory.getLogger(SQSObservableQueue.class);
 
@@ -77,8 +76,6 @@ public class SQSObservableQueue implements ObservableQueue {
 	private int batchSize;
 
 	private AmazonSQSClient client;
-
-	private int pollTimeInMS;
 
 	private String queueURL;
 
@@ -139,10 +136,6 @@ public class SQSObservableQueue implements ObservableQueue {
 	@Override
 	public String getURI() {
 		return queueURL;
-	}
-
-	public int getPollTimeInMS() {
-		return pollTimeInMS;
 	}
 
 	public int getBatchSize() {
@@ -279,7 +272,7 @@ public class SQSObservableQueue implements ObservableQueue {
 	}
 
 	@VisibleForTesting
-	List<Message> receiveMessages() {
+	protected List<Message> receiveMessages() {
 		try {
 			ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest()
 					.withQueueUrl(queueURL)
@@ -298,17 +291,6 @@ public class SQSObservableQueue implements ObservableQueue {
 			Monitors.recordObservableQMessageReceivedErrors(QUEUE_TYPE);
 		}
 		return new ArrayList<>();
-	}
-
-	@VisibleForTesting
-	OnSubscribe<Message> getOnSubscribe() {
-		return subscriber -> {
-			Observable<Long> interval = Observable.interval(pollTimeInMS, TimeUnit.MILLISECONDS);
-			interval.flatMap((Long x)->{
-				List<Message> msgs = receiveMessages();
-		        return Observable.from(msgs);
-			}).subscribe(subscriber::onNext, subscriber::onError);
-		};
 	}
 
 	private List<String> delete(List<Message> messages) {

--- a/contribs/src/main/java/com/netflix/conductor/core/events/amqp/AMQEventQueueProvider.java
+++ b/contribs/src/main/java/com/netflix/conductor/core/events/amqp/AMQEventQueueProvider.java
@@ -1,0 +1,50 @@
+package com.netflix.conductor.core.events.amqp;
+
+import com.netflix.conductor.contribs.queue.amqp.AMQObservableQueue;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.events.EventQueueProvider;
+import com.netflix.conductor.core.events.queue.ObservableQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.netflix.conductor.contribs.queue.amqp.AMQObservableQueue.Builder;
+
+/**
+ * Created at 19/03/2019 16:29
+ *
+ * @author Mickaël GREGORI <mickael.gregori@alchimie.com>
+ * @version $Id$
+ */
+@Singleton
+public class AMQEventQueueProvider implements EventQueueProvider {
+
+    private static Logger logger = LoggerFactory.getLogger(AMQEventQueueProvider.class);
+
+    protected Map<String, AMQObservableQueue> queues = new ConcurrentHashMap<>();
+
+    private final boolean useExchange;
+
+    private final Configuration config;
+
+    @Inject
+    public AMQEventQueueProvider(Configuration config, boolean useExchange) {
+        this.config = config;
+        this.useExchange = useExchange;
+    }
+
+    @Override
+    public ObservableQueue getQueue(String queueURI) {
+        if (logger.isInfoEnabled()) {
+            logger.info("Retrieve queue with URI {}", queueURI);
+        }
+        // Build the queue with the inner Builder class of AMQObservableQueue
+        final AMQObservableQueue queue = queues.computeIfAbsent(queueURI,
+                q -> new Builder(config).build(useExchange, q));
+        return queue;
+    }
+}

--- a/contribs/src/test/java/com/netflix/conductor/contribs/TestAMQModule.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/TestAMQModule.java
@@ -1,0 +1,56 @@
+package com.netflix.conductor.contribs;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.events.EventQueueProvider;
+import com.netflix.conductor.core.events.queue.ObservableQueue;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created at 22/03/2019 16:37
+ *
+ * @author Mickaël GREGORI <mickael.gregori@alchimie.com>
+ * @version $Id$
+ */
+public class TestAMQModule {
+
+    private AMQModule module;
+    private Configuration config;
+
+    @Before
+    public void setUp() {
+        module = new AMQModule();
+        config = mock(Configuration.class);
+    }
+
+    @Test
+    public void testGetAMQQueueEventQueueProvider() {
+        EventQueueProvider provider = module.getAMQQueueEventQueueProvider(config);
+        Assert.assertNotNull(provider);
+    }
+
+    @Test
+    public void testGetAMQExchangeEventQueueProvider() {
+        EventQueueProvider provider = module.getAMQExchangeEventQueueProvider(config);
+        Assert.assertNotNull(provider);
+    }
+
+    @Test
+    public void testGetQueuesWithDefaultConfiguration() {
+        when(config.getProperty(anyString(), anyString())).thenAnswer(invocation -> invocation.getArguments()[1]);
+        when(config.getBooleanProperty(anyString(), anyBoolean())).thenAnswer(invocation -> invocation.getArguments()[1]);
+        when(config.getIntProperty(anyString(), anyInt())).thenAnswer(invocation -> invocation.getArguments()[1]);
+        Map<Task.Status, ObservableQueue> queues = module.getQueues(config);
+        Assert.assertNotNull(queues);
+        Assert.assertFalse(queues.isEmpty());
+        Assert.assertEquals(2, queues.size());
+    }
+}

--- a/contribs/src/test/java/com/netflix/conductor/contribs/queue/amqp/AbstractTestAMQObservableQueue.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/queue/amqp/AbstractTestAMQObservableQueue.java
@@ -1,0 +1,218 @@
+package com.netflix.conductor.contribs.queue.amqp;
+
+import com.netflix.conductor.core.config.Configuration;
+import com.netflix.conductor.core.events.queue.Message;
+import com.rabbitmq.client.*;
+import com.rabbitmq.client.impl.AMQImpl;
+import org.apache.commons.lang3.StringUtils;
+import org.mockito.internal.stubbing.answers.DoesNothing;
+import org.mockito.internal.stubbing.answers.ReturnsArgumentAt;
+import org.mockito.internal.stubbing.answers.ReturnsElementsOf;
+import org.mockito.stubbing.Answer;
+import org.mockito.stubbing.OngoingStubbing;
+import rx.Observable;
+import rx.observers.Subscribers;
+import rx.observers.TestSubscriber;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Created at 26/03/2019 16:39
+ *
+ * @author Mickaël GREGORI <mickael.gregori@alchimie.com>
+ * @version $Id$
+ */
+abstract class AbstractTestAMQObservableQueue {
+
+    final int batchSize = 10;
+    final int pollTimeMs = 500;
+
+    Address[] addresses;
+    Configuration configuration;
+
+    AbstractTestAMQObservableQueue() {
+        configuration = mock(Configuration.class);
+        Answer answer = new ReturnsArgumentAt(1);
+        when(configuration.getProperty(anyString(), anyString())).thenAnswer(answer);
+        when(configuration.getBooleanProperty(anyString(), anyBoolean())).thenAnswer(answer);
+        when(configuration.getIntProperty(anyString(), anyInt())).thenAnswer(answer);
+        addresses = new Address[] { new Address("localhost", AMQP.PROTOCOL.PORT ) };
+    }
+
+    List<GetResponse> buildQueue(final Random random, final int bound) {
+        final LinkedList<GetResponse> queue = new LinkedList();
+        for (int i = 0; i < bound; i++) {
+            AMQP.BasicProperties props = mock(AMQP.BasicProperties.class);
+            when(props.getMessageId()).thenReturn(UUID.randomUUID().toString());
+            Envelope envelope = mock(Envelope.class);
+            when(envelope.getDeliveryTag()).thenReturn(random.nextLong());
+            GetResponse response = mock(GetResponse.class);
+            when(response.getProps()).thenReturn(props);
+            when(response.getEnvelope()).thenReturn(envelope);
+            when(response.getBody()).thenReturn("{}".getBytes());
+            when(response.getMessageCount()).thenReturn(bound - i);
+            queue.add(response);
+        }
+        return queue;
+    }
+
+
+    Channel mockBaseChannel() throws IOException, TimeoutException {
+        Channel channel = mock(Channel.class);
+        when(channel.isOpen()).thenReturn(Boolean.TRUE);
+        doAnswer(invocation -> {
+            when(channel.isOpen()).thenReturn(Boolean.FALSE);
+            return new DoesNothing();
+        }).when(channel).close();
+        return channel;
+    }
+
+    Channel mockChannelForQueue(Channel channel, boolean isWorking, boolean exists, String name,
+                                        List<GetResponse> queue) throws IOException {
+        // queueDeclarePassive
+        final AMQImpl.Queue.DeclareOk queueDeclareOK = new AMQImpl.Queue.DeclareOk(name, queue.size(), 1);
+        if (exists) {
+            when(channel.queueDeclarePassive(eq(name))).thenReturn(queueDeclareOK);
+        }
+        else {
+            when(channel.queueDeclarePassive(eq(name))).thenThrow(new IOException("Queue "+ name +" exists"));
+        }
+        // queueDeclare
+        OngoingStubbing<AMQP.Queue.DeclareOk> declareOkOngoingStubbing = when(channel.queueDeclare(eq(name), anyBoolean(), anyBoolean(), anyBoolean(), anyMap()))
+                .thenReturn(queueDeclareOK);
+        if (!isWorking) {
+            declareOkOngoingStubbing
+                    .thenThrow(new IOException("Cannot declare queue "+ name), new RuntimeException("Not working"));
+        }
+        // messageCount
+        when(channel.messageCount(eq(name))).thenReturn(1l * queue.size());
+        // basicGet
+        OngoingStubbing<GetResponse> getResponseOngoingStubbing = when(channel.basicGet(eq(name), anyBoolean()))
+                .thenAnswer(new ReturnsElementsOf(queue));
+        if (!isWorking) {
+            getResponseOngoingStubbing
+                    .thenThrow(new IOException("Not working"), new RuntimeException("Not working"));
+        }
+        // basicPublish
+        if (isWorking) {
+            doNothing().when(channel)
+                    .basicPublish(eq(StringUtils.EMPTY), eq(name), any(AMQP.BasicProperties.class), any(byte[].class));
+        }
+        else {
+            doThrow(new IOException("Not working")).when(channel)
+                    .basicPublish(eq(StringUtils.EMPTY), eq(name), any(AMQP.BasicProperties.class), any(byte[].class));
+        }
+        return channel;
+    }
+
+    Channel mockChannelForExchange(Channel channel, boolean isWorking, boolean exists, String queueName,
+                                   String name, String type, String routingKey, List<GetResponse> queue)
+            throws IOException {
+        // exchangeDeclarePassive
+        final AMQImpl.Exchange.DeclareOk exchangeDeclareOK = new AMQImpl.Exchange.DeclareOk();
+        if (exists) {
+            when(channel.exchangeDeclarePassive(eq(name))).thenReturn(exchangeDeclareOK);
+        }
+        else {
+            when(channel.exchangeDeclarePassive(eq(name))).thenThrow(new IOException("Exchange "+ name +" exists"));
+        }
+        // exchangeDeclare
+        OngoingStubbing<AMQP.Exchange.DeclareOk> declareOkOngoingStubbing = when(channel.exchangeDeclare(eq(name),
+                eq(type), anyBoolean(), anyBoolean(), anyMap()))
+                .thenReturn(exchangeDeclareOK);
+        if (!isWorking) {
+            declareOkOngoingStubbing
+                    .thenThrow(new IOException("Cannot declare exchange "+ name + " of type "+ type),
+                            new RuntimeException("Not working"));
+        }
+        // queueDeclarePassive
+        final AMQImpl.Queue.DeclareOk queueDeclareOK = new AMQImpl.Queue.DeclareOk(queueName, queue.size(), 1);
+        if (exists) {
+            when(channel.queueDeclarePassive(eq(queueName))).thenReturn(queueDeclareOK);
+        }
+        else {
+            when(channel.queueDeclarePassive(eq(queueName))).thenThrow(new IOException("Queue "+ queueName +" exists"));
+        }
+        // queueDeclare
+        when(channel.queueDeclare(eq(queueName), anyBoolean(), anyBoolean(), anyBoolean(), anyMap()))
+                .thenReturn(queueDeclareOK);
+        // queueBind
+        when(channel.queueBind(eq(queueName), eq(name), eq(routingKey))).thenReturn(new AMQImpl.Queue.BindOk());
+        // messageCount
+        when(channel.messageCount(eq(name))).thenReturn(1l * queue.size());
+        // basicGet
+        OngoingStubbing<GetResponse> getResponseOngoingStubbing = when(channel.basicGet(eq(queueName), anyBoolean()))
+                .thenAnswer(new ReturnsElementsOf(queue));
+        if (!isWorking) {
+            getResponseOngoingStubbing
+                    .thenThrow(new IOException("Not working"), new RuntimeException("Not working"));
+        }
+        // basicPublish
+        if (isWorking) {
+            doNothing().when(channel)
+                    .basicPublish(eq(name), eq(routingKey), any(AMQP.BasicProperties.class), any(byte[].class));
+        }
+        else {
+            doThrow(new IOException("Not working")).when(channel)
+                    .basicPublish(eq(name), eq(routingKey), any(AMQP.BasicProperties.class), any(byte[].class));
+        }
+        return channel;
+    }
+
+    Connection mockGoodConnection(Channel channel) throws IOException {
+        Connection connection = mock(Connection.class);
+        when(connection.createChannel()).thenReturn(channel);
+        when(connection.isOpen()).thenReturn(Boolean.TRUE);
+        doAnswer(invocation -> {
+            when(connection.isOpen()).thenReturn(Boolean.FALSE);
+            return new DoesNothing();
+        }).when(connection).close();
+        return connection;
+    }
+
+    Connection mockBadConnection() throws IOException {
+        Connection connection = mock(Connection.class);
+        when(connection.createChannel()).thenThrow(new IOException("Can't create channel"));
+        when(connection.isOpen()).thenReturn(Boolean.TRUE);
+        doThrow(new IOException("Can't close connection")).when(connection).close();
+        return connection;
+    }
+
+    ConnectionFactory mockConnectionFactory(Connection connection) throws IOException, TimeoutException {
+        ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+        when(connectionFactory.newConnection(eq(addresses))).thenReturn(connection);
+        return connectionFactory;
+    }
+
+    void runObserve(Channel channel, AMQObservableQueue observableQueue, String queueName, boolean useWorkingChannel,
+                            int batchSize) throws IOException {
+
+        final List<Message> found = new ArrayList<>(batchSize);
+        TestSubscriber<Message> subscriber = TestSubscriber.create(Subscribers.create(found::add));
+        Observable<Message> observable = observableQueue.observe().take(pollTimeMs * 2, TimeUnit.MILLISECONDS);
+        assertNotNull(observable);
+        observable.subscribe(subscriber);
+        subscriber.awaitTerminalEvent();
+        subscriber.assertNoErrors();
+        subscriber.assertCompleted();
+        if (useWorkingChannel) {
+            verify(channel, atLeast(batchSize)).basicGet(eq(queueName), anyBoolean());
+            doNothing().when(channel).basicAck(anyLong(), eq(false));
+            doAnswer(new DoesNothing()).when(channel).basicAck(anyLong(), eq(false));
+            observableQueue.ack(Collections.synchronizedList(found));
+        }
+        else {
+            assertNotNull(found);
+            assertTrue(found.isEmpty());
+        }
+        observableQueue.close();
+    }
+}

--- a/contribs/src/test/java/com/netflix/conductor/contribs/queue/amqp/TestAMQSettings.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/queue/amqp/TestAMQSettings.java
@@ -1,0 +1,65 @@
+package com.netflix.conductor.contribs.queue.amqp;
+
+import com.netflix.conductor.core.config.Configuration;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created at 22/03/2019 15:38
+ *
+ * @author Mickaël GREGORI <mickael.gregori@alchimie.com>
+ * @version $Id$
+ */
+public class TestAMQSettings {
+
+    private Configuration config;
+
+    @Before
+    public void setUp() {
+        config = mock(Configuration.class);
+    }
+
+    @Test
+    public void testQueueURIWithDefaultConfig() {
+        when(config.getProperty(anyString(), anyString())).thenAnswer(invocation -> invocation.getArguments()[1]);
+        when(config.getBooleanProperty(anyString(), anyBoolean())).thenAnswer(invocation -> invocation.getArguments()[1]);
+        when(config.getIntProperty(anyString(), anyInt())).thenAnswer(invocation -> invocation.getArguments()[1]);
+        final String queueURI = "amqp-queue:myQueueName?deliveryMode=2&durable=false&autoDelete=true&exclusive=true";
+        AMQSettings settings = new AMQSettings(config);
+        settings.fromURI(queueURI);
+        assertEquals(AMQSettings.DEFAULT_CONTENT_TYPE, settings.getContentType());
+        assertEquals(AMQSettings.DEFAULT_CONTENT_ENCODING, settings.getContentEncoding());
+        assertEquals("myQueueName", settings.getQueueOrExchangeName());
+        assertEquals(2, settings.getDeliveryMode());
+        assertEquals(false, settings.isDurable());
+        assertEquals(true, settings.isExclusive());
+        assertEquals(true, settings.autoDelete());
+        assertTrue(settings.getArguments().isEmpty());
+    }
+
+    @Test
+    public void testExchangeURIWithDefaultConfig() {
+        when(config.getProperty(anyString(), anyString())).thenAnswer(invocation -> invocation.getArguments()[1]);
+        when(config.getBooleanProperty(anyString(), anyBoolean())).thenAnswer(invocation -> invocation.getArguments()[1]);
+        when(config.getIntProperty(anyString(), anyInt())).thenAnswer(invocation -> invocation.getArguments()[1]);
+        final String queueURI = "amqp-exchange:myExchangeName?exchangeType=topic&routingKey=myRoutingKey&deliveryMode=2";
+        AMQSettings settings = new AMQSettings(config).fromURI(queueURI);
+        assertEquals("myExchangeName", settings.getQueueOrExchangeName());
+        assertEquals("topic", settings.getExchangeType());
+        assertEquals("myRoutingKey", settings.getRoutingKey());
+        assertEquals(2, settings.getDeliveryMode());
+        // default values
+        assertEquals(AMQSettings.DEFAULT_CONTENT_TYPE, settings.getContentType());
+        assertEquals(AMQSettings.DEFAULT_CONTENT_ENCODING, settings.getContentEncoding());
+        assertEquals(true, settings.isDurable());
+        assertEquals(false, settings.isExclusive()); // default value
+        assertEquals(false, settings.autoDelete()); // default value
+        assertTrue(settings.getArguments().isEmpty());
+    }
+}

--- a/contribs/src/test/java/com/netflix/conductor/contribs/queue/amqp/TestExchangeAMQObservableQueue.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/queue/amqp/TestExchangeAMQObservableQueue.java
@@ -1,0 +1,194 @@
+package com.netflix.conductor.contribs.queue.amqp;
+
+import com.netflix.conductor.core.events.queue.Message;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.GetResponse;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+import rx.Observable;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Created at 21/03/2019 16:22
+ *
+ * @author Mickaël GREGORI <mickael.gregori@alchimie.com>
+ * @version $Id$
+ */
+public class TestExchangeAMQObservableQueue extends AbstractTestAMQObservableQueue {
+
+    @Test
+    public void testGetMessagesFromExistingExchangeAndDefaultConfiguration()
+            throws IOException, TimeoutException {
+        // Mock channel and connection
+        Channel channel = mockBaseChannel();
+        Connection connection = mockGoodConnection(channel);
+        testGetMessagesFromExchangeAndDefaultConfiguration(channel, connection,true, true);
+    }
+
+    @Test
+    public void testGetMessagesFromNotExistingExchangeAndDefaultConfiguration()
+            throws IOException, TimeoutException {
+        // Mock channel and connection
+        Channel channel = mockBaseChannel();
+        Connection connection = mockGoodConnection(channel);
+        testGetMessagesFromExchangeAndDefaultConfiguration(channel, connection,false, true);
+    }
+
+    @Test
+    public void testPublishMessagesToNotExistingExchangeAndDefaultConfiguration()
+            throws IOException, TimeoutException {
+        // Mock channel and connection
+        Channel channel = mockBaseChannel();
+        Connection connection = mockGoodConnection(channel);
+        testPublishMessagesToExchangeAndDefaultConfiguration(channel, connection,false, true);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testGetMessagesFromExchangeWithBadConnection()
+            throws IOException, TimeoutException {
+        // Mock channel and connection
+        Channel channel = mockBaseChannel();
+        Connection connection = mockBadConnection();
+        testGetMessagesFromExchangeAndDefaultConfiguration(channel, connection, true, true);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testPublishMessagesToExchangeWithBadConnection()
+            throws IOException, TimeoutException {
+        // Mock channel and connection
+        Channel channel = mockBaseChannel();
+        Connection connection = mockBadConnection();
+        testPublishMessagesToExchangeAndDefaultConfiguration(channel, connection, true, true);
+    }
+
+    @Test
+    public void testGetMessagesFromExchangeWithBadChannel()
+            throws IOException, TimeoutException {
+        // Mock channel and connection
+        Channel channel = mockBaseChannel();
+        Connection connection = mockGoodConnection(channel);
+        testGetMessagesFromExchangeAndDefaultConfiguration(channel, connection, true, false);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testPublishMessagesToExchangeWithBadChannel()
+            throws IOException, TimeoutException {
+        // Mock channel and connection
+        Channel channel = mockBaseChannel();
+        Connection connection = mockGoodConnection(channel);
+        testPublishMessagesToExchangeAndDefaultConfiguration(channel, connection, true, false);
+    }
+
+    private void testGetMessagesFromExchangeAndDefaultConfiguration(Channel channel, Connection connection,
+                                                                 boolean exists, boolean useWorkingChannel)
+            throws IOException, TimeoutException {
+
+        final Random random = new Random();
+
+        final String name = RandomStringUtils.randomAlphabetic(30), type = "topic",
+                routingKey = RandomStringUtils.randomAlphabetic(30);
+        final String queueName = String.format("bound_to_%s", name);
+
+        final AMQSettings settings = new AMQSettings(configuration)
+                .fromURI("amqp-exchange:" + name +"?exchangeType="+ type +"&routingKey="+ routingKey
+                        +"&deliveryMode=2&durable=true&exclusive=false&autoDelete=true");
+        assertEquals(true, settings.isDurable());
+        assertEquals(false, settings.isExclusive());
+        assertEquals(true, settings.autoDelete());
+        assertEquals(2, settings.getDeliveryMode());
+        assertEquals(name, settings.getQueueOrExchangeName());
+        assertEquals(type, settings.getExchangeType());
+        assertEquals(routingKey, settings.getRoutingKey());
+
+        List<GetResponse> queue = buildQueue(random, batchSize);
+        channel = mockChannelForExchange(channel, useWorkingChannel, exists, queueName,
+                name, type, routingKey, queue);
+
+        AMQObservableQueue observableQueue = new AMQObservableQueue(
+                mockConnectionFactory(connection),
+                addresses, true, settings, batchSize, pollTimeMs);
+
+        assertArrayEquals(addresses, observableQueue.getAddresses());
+        assertEquals(AMQSettings.AMQP_EXCHANGE_TYPE, observableQueue.getType());
+        assertEquals(name, observableQueue.getName());
+        assertEquals(name, observableQueue.getURI());
+        assertEquals(batchSize, observableQueue.getBatchSize());
+        assertEquals(pollTimeMs, observableQueue.getPollTimeInMS());
+        assertEquals(queue.size(), observableQueue.size());
+
+        runObserve(channel, observableQueue, queueName, useWorkingChannel, batchSize);
+
+        if (useWorkingChannel) {
+            if (exists) {
+                verify(channel, atLeastOnce()).exchangeDeclarePassive(eq(name));
+            }
+            else {
+                verify(channel, atLeastOnce()).exchangeDeclare(eq(name), eq(type), eq(settings.isDurable()),
+                        eq(settings.autoDelete()), eq(Collections.emptyMap()));
+                verify(channel, atLeastOnce()).queueDeclare(eq(queueName), anyBoolean(), anyBoolean(),
+                        anyBoolean(), anyMap());
+            }
+            verify(channel, atLeastOnce()).queueBind(eq(queueName), eq(name), eq(routingKey));
+        }
+    }
+
+    private void testPublishMessagesToExchangeAndDefaultConfiguration(Channel channel, Connection connection,
+                                                                 boolean exists, boolean useWorkingChannel)
+            throws IOException, TimeoutException {
+        final Random random = new Random();
+
+        final String name = RandomStringUtils.randomAlphabetic(30), type = "topic",
+                queueName = RandomStringUtils.randomAlphabetic(30),
+                routingKey = RandomStringUtils.randomAlphabetic(30);
+
+        final AMQSettings settings = new AMQSettings(configuration)
+                .fromURI("amqp-exchange:" + name +"?exchangeType="+ type +"&routingKey="+ routingKey
+                                +"&deliveryMode=2&durable=true&exclusive=false&autoDelete=true");
+        assertEquals(true, settings.isDurable());
+        assertEquals(false, settings.isExclusive());
+        assertEquals(true, settings.autoDelete());
+        assertEquals(2, settings.getDeliveryMode());
+        assertEquals(name, settings.getQueueOrExchangeName());
+        assertEquals(type, settings.getExchangeType());
+        assertEquals(routingKey, settings.getRoutingKey());
+
+        List<GetResponse> queue = buildQueue(random, batchSize);
+        channel = mockChannelForExchange(channel, useWorkingChannel, exists, queueName,
+                name, type, routingKey, queue);
+
+        AMQObservableQueue observableQueue = new AMQObservableQueue(
+                mockConnectionFactory(connection),
+                addresses, true, settings, batchSize, pollTimeMs);
+
+        assertArrayEquals(addresses, observableQueue.getAddresses());
+        assertEquals(AMQSettings.AMQP_EXCHANGE_TYPE, observableQueue.getType());
+        assertEquals(name, observableQueue.getName());
+        assertEquals(name, observableQueue.getURI());
+        assertEquals(batchSize, observableQueue.getBatchSize());
+        assertEquals(pollTimeMs, observableQueue.getPollTimeInMS());
+        assertEquals(queue.size(), observableQueue.size());
+
+        List<Message> messages = new LinkedList<>();
+        Observable.range(0, batchSize).forEach((Integer x) -> messages.add(new Message("" + x, "payload: " + x, null)));
+        assertEquals(batchSize, messages.size());
+        observableQueue.publish(messages);
+
+        if (useWorkingChannel) {
+            verify(channel, times(batchSize)).basicPublish(eq(name), eq(routingKey),
+                    any(AMQP.BasicProperties.class), any(byte[].class));
+        }
+    }
+}

--- a/contribs/src/test/java/com/netflix/conductor/contribs/queue/amqp/TestQueueAMQObservableQueue.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/queue/amqp/TestQueueAMQObservableQueue.java
@@ -1,0 +1,161 @@
+package com.netflix.conductor.contribs.queue.amqp;
+
+import com.netflix.conductor.core.events.queue.Message;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.GetResponse;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+import rx.Observable;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Created at 21/03/2019 16:22
+ *
+ * @author Mickaël GREGORI <mickael.gregori@alchimie.com>
+ * @version $Id$
+ */
+public class TestQueueAMQObservableQueue extends AbstractTestAMQObservableQueue {
+
+    @Test
+    public void testGetMessagesFromExistingQueueAndDefaultConfiguration()
+            throws IOException, TimeoutException {
+        // Mock channel and connection
+        Channel channel = mockBaseChannel();
+        Connection connection = mockGoodConnection(channel);
+        testGetMessagesFromQueueAndDefaultConfiguration(channel, connection,true, true);
+    }
+
+    @Test
+    public void testGetMessagesFromNotExistingQueueAndDefaultConfiguration()
+            throws IOException, TimeoutException {
+        // Mock channel and connection
+        Channel channel = mockBaseChannel();
+        Connection connection = mockGoodConnection(channel);
+        testGetMessagesFromQueueAndDefaultConfiguration(channel, connection,false, true);
+    }
+
+    @Test
+    public void testPublishMessagesToNotExistingQueueAndDefaultConfiguration()
+            throws IOException, TimeoutException {
+        // Mock channel and connection
+        Channel channel = mockBaseChannel();
+        Connection connection = mockGoodConnection(channel);
+        testPublishMessagesToQueueAndDefaultConfiguration(channel, connection,false, true);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testGetMessagesFromQueueWithBadConnection()
+            throws IOException, TimeoutException {
+        // Mock channel and connection
+        Channel channel = mockBaseChannel();
+        Connection connection = mockBadConnection();
+        testGetMessagesFromQueueAndDefaultConfiguration(channel, connection, true, true);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testPublishMessagesToQueueWithBadConnection()
+            throws IOException, TimeoutException {
+        // Mock channel and connection
+        Channel channel = mockBaseChannel();
+        Connection connection = mockBadConnection();
+        testPublishMessagesToQueueAndDefaultConfiguration(channel, connection, true, true);
+    }
+
+    @Test
+    public void testGetMessagesFromQueueWithBadChannel()
+            throws IOException, TimeoutException {
+        // Mock channel and connection
+        Channel channel = mockBaseChannel();
+        Connection connection = mockGoodConnection(channel);
+        testGetMessagesFromQueueAndDefaultConfiguration(channel, connection, true, false);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testPublishMessagesToQueueWithBadChannel()
+            throws IOException, TimeoutException {
+        // Mock channel and connection
+        Channel channel = mockBaseChannel();
+        Connection connection = mockGoodConnection(channel);
+        testPublishMessagesToQueueAndDefaultConfiguration(channel, connection, true, false);
+    }
+
+    private void testGetMessagesFromQueueAndDefaultConfiguration(Channel channel, Connection connection,
+                                                                 boolean queueExists, boolean useWorkingChannel)
+            throws IOException, TimeoutException {
+        final Random random = new Random();
+
+        final String queueName = RandomStringUtils.randomAlphabetic(30);
+        AMQSettings settings = new AMQSettings(configuration).fromURI("amqp-queue:" + queueName);
+
+        List<GetResponse> queue = buildQueue(random, batchSize);
+        channel = mockChannelForQueue(channel, useWorkingChannel, queueExists, queueName, queue);
+
+        AMQObservableQueue observableQueue = new AMQObservableQueue(
+                mockConnectionFactory(connection),
+                addresses, false, settings, batchSize, pollTimeMs);
+
+        assertArrayEquals(addresses, observableQueue.getAddresses());
+        assertEquals(AMQSettings.AMQP_QUEUE_TYPE, observableQueue.getType());
+        assertEquals(queueName, observableQueue.getName());
+        assertEquals(queueName, observableQueue.getURI());
+        assertEquals(batchSize, observableQueue.getBatchSize());
+        assertEquals(pollTimeMs, observableQueue.getPollTimeInMS());
+        assertEquals(queue.size(), observableQueue.size());
+
+        runObserve(channel, observableQueue, queueName, useWorkingChannel, batchSize);
+    }
+
+    private void testPublishMessagesToQueueAndDefaultConfiguration(Channel channel, Connection connection,
+                                                                 boolean queueExists, boolean useWorkingChannel)
+            throws IOException, TimeoutException {
+        final Random random = new Random();
+
+        final String queueName = RandomStringUtils.randomAlphabetic(30);
+        final AMQSettings settings = new AMQSettings(configuration)
+                .fromURI("amqp-queue:" + queueName +"?deliveryMode=2&durable=true&exclusive=false&autoDelete=true");
+        assertEquals(true, settings.isDurable());
+        assertEquals(false, settings.isExclusive());
+        assertEquals(true, settings.autoDelete());
+        assertEquals(2, settings.getDeliveryMode());
+
+        List<GetResponse> queue = buildQueue(random, batchSize);
+        channel = mockChannelForQueue(channel, useWorkingChannel, queueExists, queueName, queue);
+
+        AMQObservableQueue observableQueue = new AMQObservableQueue(
+                mockConnectionFactory(connection),
+                addresses, false, settings, batchSize, pollTimeMs);
+
+        assertArrayEquals(addresses, observableQueue.getAddresses());
+        assertEquals(AMQSettings.AMQP_QUEUE_TYPE, observableQueue.getType());
+        assertEquals(queueName, observableQueue.getName());
+        assertEquals(queueName, observableQueue.getURI());
+        assertEquals(batchSize, observableQueue.getBatchSize());
+        assertEquals(pollTimeMs, observableQueue.getPollTimeInMS());
+        assertEquals(queue.size(), observableQueue.size());
+
+        List<Message> messages = new LinkedList<>();
+        Observable.range(0, batchSize).forEach((Integer x) -> messages.add(new Message("" + x, "payload: " + x, null)));
+        assertEquals(batchSize, messages.size());
+        observableQueue.publish(messages);
+
+        if (useWorkingChannel) {
+            verify(channel, times(batchSize)).basicPublish(eq(StringUtils.EMPTY), eq(queueName),
+                    any(AMQP.BasicProperties.class), any(byte[].class));
+        }
+    }
+
+
+}

--- a/contribs/src/test/java/com/netflix/conductor/core/events/amqp/TestAMQEventQueueProvider.java
+++ b/contribs/src/test/java/com/netflix/conductor/core/events/amqp/TestAMQEventQueueProvider.java
@@ -1,0 +1,275 @@
+package com.netflix.conductor.core.events.amqp;
+
+import com.netflix.conductor.contribs.queue.amqp.AMQObservableQueue;
+import com.netflix.conductor.contribs.queue.amqp.AMQSettings;
+import com.netflix.conductor.core.config.Configuration;
+import com.rabbitmq.client.Address;
+import com.rabbitmq.client.ConnectionFactory;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static com.netflix.conductor.contribs.queue.amqp.AMQProperties.*;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created at 21/03/2019 16:23
+ *
+ * @author Mickaël GREGORI <mickael.gregori@alchimie.com>
+ * @version $Id$
+ */
+public class TestAMQEventQueueProvider {
+
+    private Configuration configuration;
+
+    @Before
+    public void setup() {
+        configuration = mock(Configuration.class);
+    }
+
+    @Test
+    public void testGetQueueWithDefaultConfiguration() {
+        when(configuration.getProperty(anyString(), anyString())).thenAnswer(invocation -> invocation.getArguments()[1]);
+        when(configuration.getBooleanProperty(anyString(), anyBoolean())).thenAnswer(invocation -> invocation.getArguments()[1]);
+        when(configuration.getIntProperty(anyString(), anyInt())).thenAnswer(invocation -> invocation.getArguments()[1]);
+
+        final String queueUri = "test_queue_1";
+        AMQEventQueueProvider amqEventQueueProvider = new AMQEventQueueProvider(configuration, false);
+        AMQObservableQueue amqObservableQueue = (AMQObservableQueue) amqEventQueueProvider.getQueue(queueUri);
+
+        assertNotNull(amqObservableQueue);
+
+        assertNotNull(amqObservableQueue.getConnectionFactory());
+        assertEquals(ConnectionFactory.DEFAULT_HOST, amqObservableQueue.getConnectionFactory().getHost());
+        assertEquals(ConnectionFactory.DEFAULT_AMQP_PORT, amqObservableQueue.getConnectionFactory().getPort());
+        assertEquals(ConnectionFactory.DEFAULT_USER, amqObservableQueue.getConnectionFactory().getUsername());
+        assertEquals(ConnectionFactory.DEFAULT_PASS, amqObservableQueue.getConnectionFactory().getPassword());
+        assertEquals(ConnectionFactory.DEFAULT_VHOST, amqObservableQueue.getConnectionFactory().getVirtualHost());
+
+        assertTrue(amqObservableQueue.getSettings().isDurable());
+        assertFalse(amqObservableQueue.getSettings().isExclusive());
+
+        assertNotNull(amqObservableQueue.getAddresses());
+
+        assertEquals(AMQObservableQueue.AMQP_QUEUE_TYPE, amqObservableQueue.getType());
+        assertEquals(queueUri, amqObservableQueue.getSettings().getQueueOrExchangeName());
+        assertEquals(queueUri, amqObservableQueue.getURI());
+
+        assertEquals(AMQObservableQueue.DEFAULT_BATCH_SIZE, amqObservableQueue.getBatchSize());
+        assertEquals(AMQObservableQueue.DEFAULT_POLL_TIME_MS, amqObservableQueue.getPollTimeInMS());
+        assertTrue(amqObservableQueue.getSettings().getArguments().isEmpty());
+    }
+
+    private static int getRandomInt(int multiplier) {
+        return Double.valueOf(Math.random()*multiplier).intValue();
+    }
+
+    @Test
+    public void testGetQueueWithSpecificConfiguration() {
+        // Hosts
+        final Address[] addresses = new Address[]{
+                new Address("rabbit-1", getRandomInt(10000)),
+                new Address("rabbit-2", getRandomInt(10000)),
+        };
+        when(configuration.getProperty(eq("workflow.event.queues.amqp.hosts"), anyString())).
+                thenReturn(Arrays.stream(addresses).map(a -> a.toString()).collect(Collectors.joining(",")));
+
+        // Port
+        final int port = getRandomInt(10000);
+        when(configuration.getIntProperty(eq("workflow.event.queues.amqp."+ PROPERTY_PORT), anyInt())).thenReturn(port);
+
+        // Credentials
+        final String username = RandomStringUtils.randomAscii(10),
+                password =  RandomStringUtils.randomAlphanumeric(20),
+                vhost =  RandomStringUtils.randomAlphabetic(20);
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_USERNAME), anyString())).thenReturn(username);
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_PASSWORD), anyString())).thenReturn(password);
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_VIRTUAL_HOST), anyString())).thenReturn(vhost);
+        when(configuration.getIntProperty(eq("workflow.event.queues.amqp."+ PROPERTY_CONNECTION_TIMEOUT), anyInt()))
+                .thenReturn(20);
+
+        // Add priority for consume settings
+        int maxPriority = getRandomInt(10) + 1;
+        when(configuration.getIntProperty(eq("workflow.event.queues.amqp."+ PROPERTY_MAX_PRIORITY), anyInt()))
+                .thenReturn(maxPriority);
+
+        // Add polling settings
+        int batchSize = getRandomInt(100000), pollTimeInMs = getRandomInt(100000);
+        when(configuration.getIntProperty(eq("workflow.event.queues.amqp."+ PROPERTY_BATCH_SIZE), anyInt()))
+                .thenReturn(batchSize);
+        when(configuration.getIntProperty(eq("workflow.event.queues.amqp."+ PROPERTY_POLL_TIME_IN_MS), anyInt()))
+                .thenReturn(pollTimeInMs);
+
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_CONTENT_TYPE), anyString()))
+                .thenReturn(AMQSettings.DEFAULT_CONTENT_TYPE);
+
+        String contentEncoding = RandomStringUtils.randomAlphabetic(15);
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_CONTENT_ENCODING), anyString()))
+                .thenReturn(contentEncoding);
+
+        boolean isDurable = getRandomInt(10) > 5, isExclusive = getRandomInt(10) > 5,
+                autoDelete = getRandomInt(10) > 5;
+        when(configuration.getBooleanProperty(eq("workflow.event.queues.amqp."+ PROPERTY_IS_DURABLE), anyBoolean()))
+                .thenReturn(isDurable);
+        when(configuration.getBooleanProperty(eq("workflow.event.queues.amqp."+ PROPERTY_IS_EXCLUSIVE), anyBoolean()))
+                .thenReturn(isExclusive);
+        when(configuration.getBooleanProperty(eq("workflow.event.queues.amqp."+ PROPERTY_AUTO_DELETE), anyBoolean()))
+                .thenReturn(autoDelete);
+
+        final String queueUri =  RandomStringUtils.randomAlphabetic(20);
+        AMQEventQueueProvider amqEventQueueProvider = new AMQEventQueueProvider(configuration, false);
+        AMQObservableQueue amqObservableQueue = (AMQObservableQueue) amqEventQueueProvider
+                .getQueue("amqp-queue:"+ queueUri +"?maxPriority=3");
+
+        assertNotNull(amqObservableQueue);
+        assertNotNull(amqObservableQueue.getConnectionFactory());
+        assertEquals(port, amqObservableQueue.getConnectionFactory().getPort());
+        assertEquals(username, amqObservableQueue.getConnectionFactory().getUsername());
+        assertEquals(password, amqObservableQueue.getConnectionFactory().getPassword());
+        assertEquals(vhost, amqObservableQueue.getConnectionFactory().getVirtualHost());
+        assertEquals(20, amqObservableQueue.getConnectionFactory().getConnectionTimeout());
+
+        assertNotNull(amqObservableQueue.getSettings());
+        assertEquals(isDurable, amqObservableQueue.getSettings().isDurable());
+        assertEquals(isExclusive, amqObservableQueue.getSettings().isExclusive());
+        assertEquals(autoDelete, amqObservableQueue.getSettings().autoDelete());
+
+        // Check content type and encoding
+        assertEquals(contentEncoding, amqObservableQueue.getSettings().getContentEncoding());
+        assertNotNull(amqObservableQueue.getSettings().getContentType());
+        assertEquals(AMQSettings.DEFAULT_CONTENT_TYPE, amqObservableQueue.getSettings().getContentType());
+
+        // Check resolved addresses from hosts
+        assertNotNull(amqObservableQueue.getAddresses());
+        assertEquals(addresses.length, amqObservableQueue.getAddresses().length);
+        assertArrayEquals(addresses, amqObservableQueue.getAddresses());
+
+        assertEquals(AMQSettings.AMQP_QUEUE_TYPE, amqObservableQueue.getType());
+        assertEquals(queueUri, amqObservableQueue.getSettings().getQueueOrExchangeName());
+        assertEquals(queueUri, amqObservableQueue.getURI());
+
+        assertEquals(batchSize, amqObservableQueue.getBatchSize());
+        assertEquals(pollTimeInMs, amqObservableQueue.getPollTimeInMS());
+        assertFalse(amqObservableQueue.getSettings().getArguments().isEmpty());
+        assertTrue(amqObservableQueue.getSettings().getArguments().containsKey("x-max-priority"));
+        assertEquals(3, amqObservableQueue.getSettings().getArguments().get("x-max-priority"));
+    }
+
+    private void testGetQueueWithEmptyValue(String prop) {
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ prop), anyString())).
+                thenReturn(StringUtils.EMPTY);
+        AMQEventQueueProvider amqEventQueueProvider = new AMQEventQueueProvider(configuration, false);
+        amqEventQueueProvider.getQueue(RandomStringUtils.randomAlphabetic(20));
+    }
+
+    private void testGetQueueWithNegativeValue(String prop) {
+        when(configuration.getIntProperty(eq("workflow.event.queues.amqp."+ prop), anyInt())).
+                thenReturn(-1);
+        AMQEventQueueProvider amqEventQueueProvider = new AMQEventQueueProvider(configuration, false);
+        amqEventQueueProvider.getQueue(RandomStringUtils.randomAlphabetic(20));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetQueueWithEmptyHosts() {
+        testGetQueueWithEmptyValue(PROPERTY_HOSTS.toString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetQueueWithEmptyUsername() {
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_HOSTS), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        testGetQueueWithEmptyValue("username");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetQueueWithEmptyPassword() {
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_HOSTS), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_USERNAME), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        testGetQueueWithEmptyValue("password");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetQueueWithEmptyVhost() {
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_HOSTS), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_USERNAME), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_PASSWORD), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        testGetQueueWithEmptyValue(PROPERTY_VIRTUAL_HOST.toString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetQueueWithNegativePort() {
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_HOSTS), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_USERNAME), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_PASSWORD), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_VIRTUAL_HOST), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        testGetQueueWithNegativeValue(PROPERTY_PORT.toString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetQueueWithNegativeConnectionTimeout() {
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_HOSTS), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_USERNAME), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_PASSWORD), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_VIRTUAL_HOST), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getIntProperty(eq("workflow.event.queues.amqp."+ PROPERTY_PORT), anyInt())).
+                thenReturn(getRandomInt(100));
+        testGetQueueWithNegativeValue(PROPERTY_CONNECTION_TIMEOUT.toString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetQueueWithNegativeBatchSize() {
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_HOSTS), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_USERNAME), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_PASSWORD), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_VIRTUAL_HOST), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getIntProperty(eq("workflow.event.queues.amqp."+ PROPERTY_PORT), anyInt())).
+                thenReturn(getRandomInt(100));
+        when(configuration.getIntProperty(eq("workflow.event.queues.amqp."+ PROPERTY_CONNECTION_TIMEOUT), anyInt())).
+                thenReturn(getRandomInt(100));
+        testGetQueueWithNegativeValue(PROPERTY_BATCH_SIZE.toString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetQueueWithNegativePollTimeInMs() {
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_HOSTS), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_USERNAME), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_PASSWORD), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getProperty(eq("workflow.event.queues.amqp."+ PROPERTY_VIRTUAL_HOST), anyString())).
+                thenReturn(RandomStringUtils.randomAlphabetic(10));
+        when(configuration.getIntProperty(eq("workflow.event.queues.amqp."+ PROPERTY_PORT), anyInt())).
+                thenReturn(getRandomInt(100));
+        when(configuration.getIntProperty(eq("workflow.event.queues.amqp."+ PROPERTY_CONNECTION_TIMEOUT), anyInt())).
+                thenReturn(getRandomInt(100));
+        when(configuration.getIntProperty(eq("workflow.event.queues.amqp."+ PROPERTY_BATCH_SIZE), anyInt())).
+                thenReturn(getRandomInt(100));
+        testGetQueueWithNegativeValue(PROPERTY_POLL_TIME_IN_MS.toString());
+    }
+
+}

--- a/contribs/src/test/resources/log4j.properties
+++ b/contribs/src/test/resources/log4j.properties
@@ -1,0 +1,25 @@
+#
+# Copyright 2017 Netflix, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=DEBUG, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n

--- a/server/src/main/resources/server.properties
+++ b/server/src/main/resources/server.properties
@@ -44,3 +44,22 @@ EC2_AVAILABILITY_ZONE=us-east-1c
 
 # disable archival service
 workflow.archive=false
+
+# OPTIONAL (contribs) - Settings for AMQP queues (RabbitMQ)
+# You must add module AMQModule to enable support of AMQP queues
+# Here are the settings with default values:
+# workflow.event.queues.amqp.hosts=localhost
+# workflow.event.queues.amqp.username=guest
+# workflow.event.queues.amqp.password=guest
+# workflow.event.queues.amqp.virtualHost=/
+# workflow.event.queues.amqp.port=5672
+# workflow.event.queues.amqp.useNio=false
+# workflow.event.queues.amqp.batchSize=1
+# workflow.event.queues.amqp.pollTimeInMs=100
+# Use durable queue ?
+# workflow.event.queues.amqp.durable=true
+# Use exclusive queue ?
+# workflow.event.queues.amqp.exclusive=false
+# Enable support of priorities on queue. Set the max priority on message.
+# Setting is ignored if the value is lower or equals to 0
+# workflow.event.queues.amqp.maxPriority=-1

--- a/versionsOfDependencies.gradle
+++ b/versionsOfDependencies.gradle
@@ -2,6 +2,7 @@
 * Common place to define all the version dependencies */
 
 ext {
+    revAmqpClient = '5.6.0'
     revApacheCommons='2.6'
     revAwaitility = '3.1.2'
     revAwsSdk = '1.11.86'


### PR DESCRIPTION
* Add support of AMQP queues into contrib

* Add settings for AMQP queues

* Add test for AMQEventQueueProvider

* Add test for AMQEventQueueProvider

* Open connection when queue is requested only

* Add getters and make constants public for testing

* Extends syntax of queue URI to add parameters for specifying publishing target (exchange or queue)

* Extends syntax of queue URI to choose between queue or exchange and overwrite some parameters

* Extends syntax of queue URI to choose between queue or exchange and overwrite some parameters

* Do not declare a new queue each time messages an exchange is declared

* Fix my tests

* Fix my tests

* Rename "amqp-queue" to "amp" and "amqp-exchange" to "amqp_exchange"

* Move dependency to respect alphabetical order